### PR TITLE
Added relation to Iron Core in composer file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         }
     ],
     "require": {
-        "php": ">=5.2.0"
+        "php": ">=5.2.0",
+        "iron-io/iron_core": "*"
     },
     "autoload": {
         "files": ["iron_cache.phar"]


### PR DESCRIPTION
You have this relation in both the Iron Worker and Iron MQ classes so it should be added to the Iron Cache composer file as well. If not the core library will not be added if only the Cache is being used.
