### PR TITLE
Please make value 0 and "0" settable for IronCache

### DIFF
--- a/IronCache.class.php
+++ b/IronCache.class.php
@@ -50,7 +50,7 @@ class IronCache_Item {
     }
 
     public function setValue($value) {
-        if(empty($value)) {
+        if(empty($value) && $value != "0") {
             throw new InvalidArgumentException("Please specify a value");
         } else {
             $this->value = $value;


### PR DESCRIPTION
I have tried using  

```
putItem("cacheName", "key1", 0) to set the initial value to 0.
```

This results in an InvalidArgumentException:

```
public function setValue($value) {
    if(empty($value)) {
        throw new InvalidArgumentException("Please specify a value");
    } else {
        $this->value = $value;
    }
}
```

This is a very common thing to do when you set up a cache to be used as an incremental counter using incrementItem("cacheName", "key1", 1);

Since it seems like you need an existing value for "key1" to use the increment function we need to instantiate it as something, and 0 is probably the best value.

`empty()` in PHP considers 0 and "0" to be true. 

I have the change I made and it allows both 0 and "0" to be set as cache values. Only setting it to 0 will allow for incrementing it but that should be OK. I don't think it makes sense to not be able to set the value as 0 or "0" in a cache solution so I hope this will be implemented.
