### PR TITLE
Adding "use IronCore/IronCore;" to to resolve the IronCore reference

### DIFF
--- a/IronCache.class.php
+++ b/IronCache.class.php
@@ -1,4 +1,7 @@
 <?php
+
+use IronCore/IronCore;
+
 /**
  * PHP client for IronCache
  *


### PR DESCRIPTION
Composer is reporting errors from this library, saying cannot find IronCore. Added "use IronCore/IronCore;" to help resolve the reference correctly.